### PR TITLE
Update to OkHttp mockwebserver3 5.0.0

### DIFF
--- a/pki/src/test/java/com/dsingley/jwt/pki/IntegrationTests.java
+++ b/pki/src/test/java/com/dsingley/jwt/pki/IntegrationTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -35,7 +36,7 @@ class IntegrationTests {
     static JwtManager jwtManager;
 
     @BeforeAll
-    static void setUp() {
+    static void setUp() throws IOException {
         TestPKI testPKI = new TestPKI(KeyType.RSA_2048, null);
         TestPKICertificate serverCertificate = testPKI.getOrCreateServerCertificate("jwt-issuer", Collections.singleton("localhost"));
 
@@ -51,6 +52,7 @@ class IntegrationTests {
                         .build();
             }
         });
+        mockWebServer.start();
 
         keyId = String.format("%s#%s", mockWebServer.url("/"), serverCertificate.getPublicKeyFingerprintSHA256());
         SigningAlgorithmSupplier signingAlgorithmSupplier = new KeyPairSigningAlgorithmSupplier(JWT_ALGORITHM, serverCertificate.getKeyPair(), keyId);
@@ -75,7 +77,7 @@ class IntegrationTests {
     @AfterAll
     static void tearDown() throws Exception {
         if (mockWebServer != null) {
-            mockWebServer.shutdown();
+            mockWebServer.close();
         }
     }
 

--- a/pki/src/test/java/com/dsingley/jwt/pki/KeysTest.java
+++ b/pki/src/test/java/com/dsingley/jwt/pki/KeysTest.java
@@ -17,11 +17,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.net.URI;
 import java.net.URL;
 import java.security.KeyPair;
 import java.security.KeyStore;
-import java.security.Security;
-import java.util.Arrays;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -124,8 +123,9 @@ class KeysTest {
                                 .build();
                     }
                 });
+                mockWebServer.start();
 
-                URL url = new URL(mockWebServer.url("/").toString());
+                URL url = URI.create(mockWebServer.url("/").toString()).toURL();
                 HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
                 connection.setSSLSocketFactory(sslSocketFactory);
                 connection.connect();

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
         <junit.version>5.13.3</junit.version>
         <assertj.version>3.27.3</assertj.version>
-        <mockwebserver3.version>5.0.0-alpha.14</mockwebserver3.version>
+        <mockwebserver3.version>5.0.0</mockwebserver3.version>
         <testpki.version>0.5.0</testpki.version>
 
         <maven-surefire.version>3.5.3</maven-surefire.version>


### PR DESCRIPTION
* Change shutdown to close (method was removed) in IntegrationTests.
* Need to explicitly start MockWebServer now (no auto-start) in KeysTest and IntegrationTests
* Remove unused imports in KeysTest
* Fix deprecated API usage (URL constructor) in KeysTest